### PR TITLE
dyngraph: fix lines with leading-"0." decimals being dropped

### DIFF
--- a/usefulcmd/dyngraph.c
+++ b/usefulcmd/dyngraph.c
@@ -62,6 +62,7 @@ double SimpleReadNumber( char ** number_ptr, double defaultNumber, int override_
 			number+=2;
 			if( nc == 0 ) { *number_ptr = number-1; return 0; }
 			else if( nc == 'x' ) radix = 16;
+			else if( nc == '.' ) number -= 2; // "0.5" is a decimal fraction, not octal - rewind so strtod sees the whole token
 			else if( nc == ' ' || nc == '\t' || nc == ',' || nc == ';' ) { *number_ptr = number-1; return 0; }
 			else if( nc == 'b' ) radix = 2;
 			else { number--; radix = 8; }


### PR DESCRIPTION
Watched the [The Worlds Cheapest Time Domain Reflectometer](https://www.youtube.com/watch?v=1vs_WxC2Odo) video and liked `dyngraph` in it and wanted to use it myself too. Accidentally found a bug so I'm sending a PR to fix it.

SimpleReadNumber routes any token starting with `0` into the radix-sniffing branch, so plain decimals like `0.5` fall through to the octal case where `strtoll` stops at the `.` without consuming any digits. The parser returns NaN, dyngraph stops reading the line, and the entire remainder is discarded (`fields_count` = 0) - any stream whose values sit between 0 and 1 renders an empty graph. Repro: `printf '0.5 0.25\n' | dyngraph`. The same happens for `0.000000e+00`, which is what `printf %e` emits for zero.

Fix: when the character after the leading `0` is `.`, rewind and let the existing strtod path parse the token as base 10. `0x` hex, `0b` binary, `012` octal, bare `0`, and negative `-0.5` behavior are unchanged.